### PR TITLE
Release 16.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pyOpenSSL" %}
-{% set version = "16.0.0" %}
+{% set version = "16.2.0" %}
 {% set hash_type = "sha256" %}
-{% set hash = "363d10ee43d062285facf4e465f4f5163f9f702f9134f0a5896f134cbb92d17d" %}
+{% set hash = "7779a3bbb74e79db234af6a08775568c6769b5821faecf6e2f4143edb227516e" %}
 
 package:
   name: {{ name|lower }}
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - cryptography >=1.3
+    - cryptography >=1.3.4
     - six >=1.5.2
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ test:
 about:
   home: https://github.com/pyca/pyopenssl
   license: Apache 2.0
+  license_family: Apache
   license_file: LICENSE
   summary: Python wrapper module around the OpenSSL library
   description: |


### PR DESCRIPTION
```rst
16.2.0 (2016-10-15)
-------------------

Backward-incompatible changes:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

*none*


Deprecations:
^^^^^^^^^^^^^

*none*


Changes:
^^^^^^^^

- Fixed compatibility errors with OpenSSL 1.1.0.
- Fixed an issue that caused failures with subinterpreters and embedded Pythons.
  `#552 <https://github.com/pyca/pyopenssl/pull/552>`_


----


16.1.0 (2016-08-26)
-------------------

Backward-incompatible changes:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

*none*


Deprecations:
^^^^^^^^^^^^^

- Dropped support for OpenSSL 0.9.8.


Changes:
^^^^^^^^

- Fix memory leak in ``OpenSSL.crypto.dump_privatekey()`` with ``FILETYPE_TEXT``.
  `#496 <https://github.com/pyca/pyopenssl/pull/496>`_
- Enable use of CRL (and more) in verify context.
  `#483 <https://github.com/pyca/pyopenssl/pull/483>`_
- ``OpenSSL.crypto.PKey`` can now be constructed from ``cryptography`` objects and also exported as such.
  `#439 <https://github.com/pyca/pyopenssl/pull/439>`_
- Support newer versions of ``cryptography`` which use opaque structs for OpenSSL 1.1.0 compatibility.
```