### PR TITLE
Update min version for `cryptography` dependancy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - pip
   run:
     - python
-    - cryptography >=1.9
+    - cryptography >=2.1.4
     - six >=1.5.2
 
 test:


### PR DESCRIPTION
Resolves https://github.com/conda-forge/pyopenssl-feedstock/issues/7
As per below, version 17.5.0 of `pyopenssl` requires at least v2.1.4 of `cryptography`.
https://github.com/pyca/pyopenssl/blob/d21fcd810317aa7579af0c194a61af377ade7f0e/setup.py#L98